### PR TITLE
fix: update mongo iterators

### DIFF
--- a/persistence/mongo/utils.go
+++ b/persistence/mongo/utils.go
@@ -3,13 +3,13 @@ package keelmongo
 import (
 	"context"
 
+	"github.com/foomo/keel/log"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // CloseCursor with defer
-func CloseCursor(ctx context.Context, cursor *mongo.Cursor, err *error) {
-	cErr := cursor.Close(ctx)
-	if *err == nil {
-		*err = cErr
+func CloseCursor(cursor *mongo.Cursor) {
+	if err := cursor.Close(context.Background()); err != nil {
+		log.WithError(nil, err).Error("failed to close cursor")
 	}
 }


### PR DESCRIPTION
- use background context on close
- return cursor error