### PR TITLE
fix(mongo): guard package-level dbs/indices registry with RWMutex

### DIFF
--- a/persistence/mongo/collection.go
+++ b/persistence/mongo/collection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"sync"
 	"time"
 
 	keelpersistence "github.com/foomo/keel/persistence"
@@ -13,6 +14,17 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
+)
+
+// dbs and indices form a package-level registry of every collection and
+// named index ever created via NewCollection. It exists purely so Readme()
+// can render the docs table — nothing in the runtime path reads it.
+// registryMu guards both maps: NewCollection writes them and Readme reads
+// them, potentially from different goroutines.
+var (
+	dbs        = map[string][]string{}
+	indices    = map[string]map[string][]string{}
+	registryMu sync.RWMutex
 )
 
 type (
@@ -117,6 +129,12 @@ func NewCollection(db *mongo.Database, name string, opts ...CollectionOption) (*
 	}
 
 	col := db.Collection(name, o.CollectionOptionsBuilder)
+
+	// Take a write lock for the rest of the function: both dbs and indices
+	// are package-level maps and we may mutate either (or both) below.
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
 	if !slices.Contains(dbs[db.Name()], name) {
 		dbs[db.Name()] = append(dbs[db.Name()], name)
 	}

--- a/persistence/mongo/readme.go
+++ b/persistence/mongo/readme.go
@@ -6,15 +6,15 @@ import (
 	"github.com/foomo/keel/markdown"
 )
 
-var (
-	dbs     = map[string][]string{}
-	indices = map[string]map[string][]string{}
-)
-
 func Readme() string {
 	var rows [][]string
 
 	md := &markdown.Markdown{}
+
+	// Read-lock the registries while we iterate them; NewCollection may be
+	// writing concurrently from other goroutines.
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 
 	for db, collections := range dbs {
 		for _, collection := range collections {


### PR DESCRIPTION
### Description

NewCollection mutated the doc-registry maps without synchronization, racing with itself when called concurrently from different goroutines and with Readme.

### Type of Change

<!-- Check the relevant option -->

- [x ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ x] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

### Changes

Add a mutex to safeguard access to package wide maps.

### Checklist

- [ x] My code adheres to the coding and style guidelines of the project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented on my code, particularly in hard-to-understand areas.
- [ x] I have made corresponding changes to the documentation.

### Notes
