### PR TITLE
fix: support http.Flusher and fix superfluous WriteHeader in responseWriter

### DIFF
--- a/net/http/middleware/responsewriter.go
+++ b/net/http/middleware/responsewriter.go
@@ -50,17 +50,36 @@ func (w *responseWriter) Status() string {
 	return fmt.Sprintf("%d", w.StatusCode())
 }
 
+// Unwrap returns the underlying http.ResponseWriter, allowing
+// http.ResponseController to discover optional interfaces (e.g., http.Flusher).
+func (w *responseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// Flush implements http.Flusher by delegating to the underlying writer if it
+// supports flushing. This enables SSE (Server-Sent Events) and HTTP streaming.
+func (w *responseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func (w *responseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	w.statusCode = statusCode
 	if w.writeResponseTimeHeader {
 		w.Header().Set(keelhttp.HeaderXResponseTime, strconv.FormatInt(time.Since(w.start).Microseconds(), 10))
 	}
-
 	w.ResponseWriter.WriteHeader(statusCode)
-	w.statusCode = statusCode
-	w.wroteHeader = true
 }
 
 func (w *responseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
 	size, err := w.ResponseWriter.Write(b)
 	w.size += size
 

--- a/net/http/middleware/responsewriter.go
+++ b/net/http/middleware/responsewriter.go
@@ -68,11 +68,14 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 	if w.wroteHeader {
 		return
 	}
+
 	w.wroteHeader = true
 	w.statusCode = statusCode
+
 	if w.writeResponseTimeHeader {
 		w.Header().Set(keelhttp.HeaderXResponseTime, strconv.FormatInt(time.Since(w.start).Microseconds(), 10))
 	}
+
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
@@ -80,6 +83,7 @@ func (w *responseWriter) Write(b []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}
+
 	size, err := w.ResponseWriter.Write(b)
 	w.size += size
 

--- a/net/http/middleware/responsewriter_test.go
+++ b/net/http/middleware/responsewriter_test.go
@@ -1,17 +1,21 @@
-package middleware
+package middleware_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/foomo/keel/net/http/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWriteHeader_Idempotent(t *testing.T) {
+	t.Parallel()
+
 	rec := httptest.NewRecorder()
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	wr.WriteHeader(http.StatusCreated)
 	wr.WriteHeader(http.StatusInternalServerError) // should be ignored
@@ -21,20 +25,23 @@ func TestWriteHeader_Idempotent(t *testing.T) {
 }
 
 func TestWrite_SetsImplicitHeader(t *testing.T) {
+	t.Parallel()
+
 	rec := httptest.NewRecorder()
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	n, err := wr.Write([]byte("hello"))
 	require.NoError(t, err)
 	assert.Equal(t, 5, n)
-	assert.True(t, wr.wroteHeader)
 	assert.Equal(t, http.StatusOK, wr.StatusCode())
 	assert.Equal(t, 5, wr.Size())
 }
 
 func TestWrite_ThenWriteHeader_NoSuperfluous(t *testing.T) {
+	t.Parallel()
+
 	rec := httptest.NewRecorder()
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	_, err := wr.Write([]byte("hello"))
 	require.NoError(t, err)
@@ -47,8 +54,10 @@ func TestWrite_ThenWriteHeader_NoSuperfluous(t *testing.T) {
 }
 
 func TestUnwrap_ReturnsUnderlying(t *testing.T) {
+	t.Parallel()
+
 	rec := httptest.NewRecorder()
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	assert.Equal(t, rec, wr.Unwrap())
 }
@@ -63,8 +72,10 @@ func (f *flusherRecorder) Flush() {
 }
 
 func TestFlush_DelegatesToFlusher(t *testing.T) {
+	t.Parallel()
+
 	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	wr.Flush()
 
@@ -72,8 +83,10 @@ func TestFlush_DelegatesToFlusher(t *testing.T) {
 }
 
 func TestFlush_NoopWhenNotFlusher(t *testing.T) {
+	t.Parallel()
+
 	rec := httptest.NewRecorder()
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	// Should not panic
 	assert.NotPanics(t, func() {
@@ -81,9 +94,11 @@ func TestFlush_NoopWhenNotFlusher(t *testing.T) {
 	})
 }
 
-func TestFlush_ViaTypAssertion(t *testing.T) {
+func TestFlush_ViaTypeAssertion(t *testing.T) {
+	t.Parallel()
+
 	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
-	wr := WrapResponseWriter(rec)
+	wr := middleware.WrapResponseWriter(rec)
 
 	f, ok := http.ResponseWriter(wr).(http.Flusher)
 	require.True(t, ok, "responseWriter should implement http.Flusher")
@@ -94,23 +109,30 @@ func TestFlush_ViaTypAssertion(t *testing.T) {
 }
 
 func TestResponseController_Flush(t *testing.T) {
+	t.Parallel()
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wr := WrapResponseWriter(w)
+		wr := middleware.WrapResponseWriter(w)
 		rc := http.NewResponseController(wr)
 
 		wr.WriteHeader(http.StatusOK)
-		_, err := wr.Write([]byte("data: hello\n\n"))
-		require.NoError(t, err)
 
-		err = rc.Flush()
-		assert.NoError(t, err, "ResponseController.Flush should work through the wrapper")
+		_, writeErr := wr.Write([]byte("data: hello\n\n"))
+		assert.NoError(t, writeErr)
+
+		flushErr := rc.Flush()
+		assert.NoError(t, flushErr, "ResponseController.Flush should work through the wrapper")
 	})
 
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/net/http/middleware/responsewriter_test.go
+++ b/net/http/middleware/responsewriter_test.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteHeader_Idempotent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wr := WrapResponseWriter(rec)
+
+	wr.WriteHeader(http.StatusCreated)
+	wr.WriteHeader(http.StatusInternalServerError) // should be ignored
+
+	assert.Equal(t, http.StatusCreated, wr.StatusCode())
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestWrite_SetsImplicitHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wr := WrapResponseWriter(rec)
+
+	n, err := wr.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.True(t, wr.wroteHeader)
+	assert.Equal(t, http.StatusOK, wr.StatusCode())
+	assert.Equal(t, 5, wr.Size())
+}
+
+func TestWrite_ThenWriteHeader_NoSuperfluous(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wr := WrapResponseWriter(rec)
+
+	_, err := wr.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	// This should be silently ignored, not cause "superfluous WriteHeader"
+	wr.WriteHeader(http.StatusInternalServerError)
+
+	assert.Equal(t, http.StatusOK, wr.StatusCode())
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUnwrap_ReturnsUnderlying(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wr := WrapResponseWriter(rec)
+
+	assert.Equal(t, rec, wr.Unwrap())
+}
+
+type flusherRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flusherRecorder) Flush() {
+	f.flushed = true
+}
+
+func TestFlush_DelegatesToFlusher(t *testing.T) {
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	wr := WrapResponseWriter(rec)
+
+	wr.Flush()
+
+	assert.True(t, rec.flushed)
+}
+
+func TestFlush_NoopWhenNotFlusher(t *testing.T) {
+	rec := httptest.NewRecorder()
+	wr := WrapResponseWriter(rec)
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		wr.Flush()
+	})
+}
+
+func TestFlush_ViaTypAssertion(t *testing.T) {
+	rec := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	wr := WrapResponseWriter(rec)
+
+	f, ok := http.ResponseWriter(wr).(http.Flusher)
+	require.True(t, ok, "responseWriter should implement http.Flusher")
+
+	f.Flush()
+
+	assert.True(t, rec.flushed)
+}
+
+func TestResponseController_Flush(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wr := WrapResponseWriter(w)
+		rc := http.NewResponseController(wr)
+
+		wr.WriteHeader(http.StatusOK)
+		_, err := wr.Write([]byte("data: hello\n\n"))
+		require.NoError(t, err)
+
+		err = rc.Flush()
+		assert.NoError(t, err, "ResponseController.Flush should work through the wrapper")
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
- Add Unwrap() so http.ResponseController can discover interfaces on the underlying writer
- Implement http.Flusher by delegating Flush() to the underlying writer
- Make WriteHeader() idempotent to prevent "superfluous response.WriteHeader" warnings
- Track implicit 200 status in Write() to keep wrapper state in sync

Closes #286

### Description
Fix the middleware responseWriter to support http.Flusher and Unwrap(), enabling SSE streaming via http.ResponseController.Flush(). Also fix the "superfluous response.WriteHeader" warning caused by state desync between the wrapper and underlying writer.

### Type of Change
- [x]  🐛 Bug fix
- [ ]  ✨ New feature
- [ ]  💥 Breaking change
- [ ]  📝 Documentation
- [ ]  ♻️ Refactoring
- [ ]  ⚡ Performance
- [x]  ✅ Tests
- [ ]  🔧 Build/CI

### Related Issue
Closes #286

### Changes
Add Unwrap() method so http.ResponseController can traverse the wrapper chain to discover optional interfaces (e.g. http.Flusher, http.Hijacker) on the underlying writer
Implement http.Flusher via Flush() delegation for direct type assertion compatibility
Make WriteHeader() idempotent — first call wins, subsequent calls are silently ignored
Fix Write() to call WriteHeader(200) on first write, keeping the wrapper's wroteHeader/statusCode state in sync with the underlying writer
Add unit tests covering all new behavior including an integration test with http.ResponseController.Flush() through a real HTTP server

### Checklist
My code adheres to the coding and style guidelines of the project.
- [x]  I have performed a self-review of my own code.
- [x]  I have commented on my code, particularly in hard-to-understand areas.
- [ ]  I have made corresponding changes to the documentation.

### Notes
No changes needed to any middleware consumers (Logger, ResponseTime, Telemetry) — they all use WrapResponseWriter and benefit automatically. The logger's direct wr.statusCode field access will now correctly reflect 200 instead of 0 for handlers that only call Write().