### PR TITLE
Fix: expose temporal connection options and fix error handling & possible nil dereferences

### DIFF
--- a/integration/temporal/client.go
+++ b/integration/temporal/client.go
@@ -99,23 +99,19 @@ func NewClient(ctx context.Context, endpoint string, opts ...ClientOption) (clie
 			}
 		} else if err != nil {
 			return nil, errors.Wrap(err, "failed to retrieve temporal namespace info")
-		}
-
-		if ns.GetNamespaceInfo().State != enums.NAMESPACE_STATE_REGISTERED { //nolint:nosnakecase
-			return nil, errors.New("Could not register namespace due to existing state: " + ns.GetNamespaceInfo().State.String())
-		}
-
-		if err := nsc.Update(ctx, &workflowservice.UpdateNamespaceRequest{
+		} else if state := ns.GetNamespaceInfo().GetState(); state != enums.NAMESPACE_STATE_REGISTERED { //nolint:nosnakecase
+			return nil, errors.New("Could not register namespace due to existing state: " + state.String())
+		} else if err := nsc.Update(ctx, &workflowservice.UpdateNamespaceRequest{
 			Namespace: o.RegisterNamespace.Namespace,
 			UpdateInfo: &namespace.UpdateNamespaceInfo{
 				Description: o.RegisterNamespace.Description,
 				OwnerEmail:  o.RegisterNamespace.OwnerEmail,
 				Data:        o.RegisterNamespace.Data,
-				State:       ns.GetNamespaceInfo().State,
+				State:       state,
 			},
 			Config: &namespace.NamespaceConfig{
 				WorkflowExecutionRetentionTtl: o.RegisterNamespace.WorkflowExecutionRetentionPeriod,
-				BadBinaries:                   ns.Config.BadBinaries,
+				BadBinaries:                   ns.GetConfig().GetBadBinaries(),
 				HistoryArchivalState:          o.RegisterNamespace.HistoryArchivalState,
 				HistoryArchivalUri:            o.RegisterNamespace.HistoryArchivalUri,
 				VisibilityArchivalState:       o.RegisterNamespace.VisibilityArchivalState,
@@ -124,13 +120,13 @@ func NewClient(ctx context.Context, endpoint string, opts ...ClientOption) (clie
 			ReplicationConfig: &replication.NamespaceReplicationConfig{
 				ActiveClusterName: o.RegisterNamespace.ActiveClusterName,
 				Clusters:          o.RegisterNamespace.Clusters,
-				State:             ns.ReplicationConfig.State,
+				State:             ns.GetReplicationConfig().GetState(),
 			},
 			SecurityToken:    o.RegisterNamespace.SecurityToken,
 			DeleteBadBinary:  "",
 			PromoteNamespace: false,
 		}); err != nil {
-			return nil, errors.Wrap(err, "failed to register temporal namespace")
+			return nil, errors.Wrap(err, "failed to update temporal namespace")
 		}
 
 		clientOpts.Namespace = o.RegisterNamespace.Namespace

--- a/integration/temporal/client.go
+++ b/integration/temporal/client.go
@@ -3,7 +3,6 @@ package keeltemporal
 import (
 	"context"
 
-	goerrors "github.com/foomo/go/errors"
 	"github.com/foomo/keel/env"
 	"github.com/foomo/keel/log"
 	"github.com/foomo/keel/telemetry"
@@ -86,10 +85,15 @@ func NewClient(ctx context.Context, endpoint string, opts ...ClientOption) (clie
 
 	// setup namespace
 	if o.RegisterNamespace != nil {
-		ns, err := nsc.Describe(ctx, o.RegisterNamespace.Namespace)
 		// Temporal's NamespaceClient.Describe returns *serviceerror.NamespaceNotFound on current
 		// servers; older servers returned *serviceerror.NotFound. Both are treated as "missing".
-		if goerrors.AsAnyType(err, &serviceerror.NotFound{}, &serviceerror.NamespaceNotFound{}) {
+		var (
+			notFoundErr          *serviceerror.NotFound
+			namespaceNotFoundErr *serviceerror.NamespaceNotFound
+		)
+
+		ns, err := nsc.Describe(ctx, o.RegisterNamespace.Namespace)
+		if errors.As(err, &notFoundErr) || errors.As(err, &namespaceNotFoundErr) {
 			if err := nsc.Register(ctx, o.RegisterNamespace); err != nil {
 				return nil, errors.Wrap(err, "failed to register temporal namespace")
 			}

--- a/integration/temporal/client.go
+++ b/integration/temporal/client.go
@@ -25,6 +25,7 @@ type (
 		Namespace         string
 		RegisterNamespace *workflowservice.RegisterNamespaceRequest
 		OtelEnabled       bool
+		ConnectionOptions client.ConnectionOptions
 	}
 	ClientOption func(o *ClientOptions)
 )
@@ -47,12 +48,19 @@ func ClientWithRegisterNamespace(v *workflowservice.RegisterNamespaceRequest) Cl
 	}
 }
 
+func ClientWithConnectionOptions(v client.ConnectionOptions) ClientOption {
+	return func(o *ClientOptions) {
+		o.ConnectionOptions = v
+	}
+}
+
 func DefaultClientOptions() ClientOptions {
 	return ClientOptions{
 		Logger:            log.Logger(),
 		Namespace:         "default",
 		RegisterNamespace: nil,
 		OtelEnabled:       env.GetBool("OTEL_TEMPORAL_ENABLED", env.GetBool("OTEL_ENABLED", false)),
+		ConnectionOptions: client.ConnectionOptions{},
 	}
 }
 
@@ -65,9 +73,10 @@ func NewClient(ctx context.Context, endpoint string, opts ...ClientOption) (clie
 	}
 
 	clientOpts := client.Options{
-		HostPort:  endpoint,
-		Namespace: o.Namespace,
-		Logger:    NewLogger(o.Logger),
+		HostPort:          endpoint,
+		Namespace:         o.Namespace,
+		Logger:            NewLogger(o.Logger),
+		ConnectionOptions: o.ConnectionOptions,
 	}
 
 	nsc, err := client.NewNamespaceClient(clientOpts)

--- a/integration/temporal/go.mod
+++ b/integration/temporal/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 replace github.com/foomo/keel => ../../
 
 require (
-	github.com/foomo/go v0.13.0
 	github.com/foomo/keel v0.27.1
 	github.com/pkg/errors v0.9.1
 	go.opentelemetry.io/otel v1.44.0
@@ -24,6 +23,7 @@ require (
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/fbiville/markdown-table-formatter v0.3.0 // indirect
+	github.com/foomo/go v0.13.0 // indirect
 	github.com/foomo/opentelemetry-go v0.4.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect


### PR DESCRIPTION
### Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch

### Description

This PR addresses 3 issues:

1. Older versions of temporal do not support GRPC Compression, which by default is now set to GrpcCompressionGzip. keeltemporal.NewClient() currently doesn't offer a way to configure the ConnectionOptions so this PR adds `ClientWithConnectionOptions`.

2. The error handling after `nsc.Describe()` is currently broken since `goerrors.AsAnyType()` matches any non-nil error:
```go
import (
	"fmt"
	"testing"

	goerrors "github.com/foomo/go/errors"
	"go.temporal.io/api/serviceerror"
)

func TestAsAnyErr(t *testing.T) {
	err := fmt.Errorf("some unknown error")
	if goerrors.AsAnyType(err, &serviceerror.NotFound{}) {
		t.Fatal("expected goerrors.AsAnyType to not match err to serviceerror.NotFound")
	}
}

```
This PR fixes that by using std lib `errors.As()`

3. If `nsc.Describe()` failed, but `nsc.Register()` didn't the code paniced on line 91 because `ns` is nil. This PR chains the if since there's nothing for `nsc.Update()` to do if `nsc.Register()` was called.

### Related Issues

none

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
