### PR TITLE
fix: mongo collecction with indexes max time

### DIFF
--- a/persistence/mongo/collection.go
+++ b/persistence/mongo/collection.go
@@ -141,9 +141,9 @@ func NewCollection(db *mongo.Database, name string, opts ...CollectionOption) (*
 
 	if len(o.Indexes) > 0 {
 		if err := func(ctx context.Context) error {
-
 			if o.IndexesMaxTime > 0 {
 				var cancel context.CancelFunc
+
 				ctx, cancel = context.WithTimeout(ctx, o.IndexesMaxTime)
 				defer cancel()
 			}

--- a/persistence/mongo/collection.go
+++ b/persistence/mongo/collection.go
@@ -42,7 +42,7 @@ type (
 		*options.CollectionOptionsBuilder
 		*options.CreateIndexesOptionsBuilder
 		Indexes        []mongo.IndexModel
-		IndexesContext context.Context
+		IndexesMaxTime time.Duration
 	}
 	CollectionOption func(*CollectionOptions)
 )
@@ -55,7 +55,6 @@ func DefaultCollectionOptions() CollectionOptions {
 	return CollectionOptions{
 		CollectionOptionsBuilder:    options.Collection(),
 		CreateIndexesOptionsBuilder: options.CreateIndexes(),
-		IndexesContext:              context.Background(),
 	}
 }
 
@@ -89,30 +88,31 @@ func CollectionWithIndexes(v ...mongo.IndexModel) CollectionOption {
 	}
 }
 
-// Deprecated: MaxTime has been removed in mongo-driver v2. Use context timeout instead.
-func CollectionWithIndexesMaxTime(_ time.Duration) CollectionOption {
-	return func(_ *CollectionOptions) {}
+func CollectionWithIndexesMaxTime(v time.Duration) CollectionOption {
+	return func(o *CollectionOptions) {
+		o.IndexesMaxTime = v
+	}
 }
 
-func CollectionWithIndexesContext(v int32) CollectionOption {
+func CollectionWithCommitQuorumInt(v int32) CollectionOption {
 	return func(o *CollectionOptions) {
 		o.SetCommitQuorumInt(v)
 	}
 }
 
-func CollectionWithIndexesQuorumMajority() CollectionOption {
+func CollectionWithCommitQuorumMajority() CollectionOption {
 	return func(o *CollectionOptions) {
 		o.SetCommitQuorumMajority()
 	}
 }
 
-func CollectionWithIndexesCommitQuorumString(v string) CollectionOption {
+func CollectionWithCommitQuorumString(v string) CollectionOption {
 	return func(o *CollectionOptions) {
 		o.SetCommitQuorumString(v)
 	}
 }
 
-func CollectionWithIndexesCommitQuorumVotingMembers(v context.Context) CollectionOption {
+func CollectionWithCommitQuorumVotingMembers(v context.Context) CollectionOption {
 	return func(o *CollectionOptions) {
 		o.SetCommitQuorumVotingMembers()
 	}
@@ -140,25 +140,38 @@ func NewCollection(db *mongo.Database, name string, opts ...CollectionOption) (*
 	}
 
 	if len(o.Indexes) > 0 {
-		if _, err := col.Indexes().CreateMany(o.IndexesContext, o.Indexes, o.CreateIndexesOptionsBuilder); err != nil {
-			return nil, err
-		}
+		if err := func(ctx context.Context) error {
 
-		if _, ok := indices[db.Name()]; !ok {
-			indices[db.Name()] = map[string][]string{}
-		}
+			if o.IndexesMaxTime > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, o.IndexesMaxTime)
+				defer cancel()
+			}
 
-		for _, index := range o.Indexes {
-			if index.Options != nil {
-				var indexOpts options.IndexOptions
-				for _, set := range index.Options.Opts {
-					_ = set(&indexOpts)
-				}
+			if _, err := col.Indexes().CreateMany(ctx, o.Indexes, o.CreateIndexesOptionsBuilder); err != nil {
+				return err
+			}
 
-				if indexOpts.Name != nil {
-					indices[db.Name()][name] = append(indices[db.Name()][name], *indexOpts.Name)
+			if _, ok := indices[db.Name()]; !ok {
+				indices[db.Name()] = map[string][]string{}
+			}
+
+			for _, index := range o.Indexes {
+				if index.Options != nil {
+					var indexOpts options.IndexOptions
+					for _, set := range index.Options.Opts {
+						_ = set(&indexOpts)
+					}
+
+					if indexOpts.Name != nil {
+						indices[db.Name()][name] = append(indices[db.Name()][name], *indexOpts.Name)
+					}
 				}
 			}
+
+			return nil
+		}(context.Background()); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
### Description

Reimplement `CollectionWithIndexesMaxTime` with a context timeout (mongo-driver v2 dropped `MaxTime`) and fix mistakenly renamed `CollectionWith*` option functions.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- `CollectionWithIndexesMaxTime` no longer no-op; wraps index creation in a `context.WithTimeout` using the given duration.
- Replaced `IndexesContext` field with `IndexesMaxTime time.Duration` on `CollectionOptions`.
- Renamed mistyped option funcs to match what they actually set: `CollectionWithIndexesContext` → `CollectionWithCommitQuorumInt`, `CollectionWithIndexesQuorumMajority` → `CollectionWithCommitQuorumMajority`, `CollectionWithIndexesCommitQuorumString` → `CollectionWithCommitQuorumString`, `CollectionWithIndexesCommitQuorumVotingMembers` → `CollectionWithCommitQuorumVotingMembers`.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
