### PR TITLE
feat: add response controller middleware

### DIFF
--- a/net/http/middleware/maxrequestbodysize.go
+++ b/net/http/middleware/maxrequestbodysize.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	keelhttp "github.com/foomo/keel/net/http"
+)
+
+// MaxRequestBodySize middleware caps the request body at n bytes.
+//
+// A declared Content-Length over the limit is rejected before the handler runs;
+// otherwise the body is wrapped with http.MaxBytesReader, so a chunked or lying
+// client fails on read with *http.MaxBytesError once it exceeds n. Handlers that
+// read the body should surface that as 413:
+//
+//	var maxErr *http.MaxBytesError
+//	if errors.As(err, &maxErr) { ... }
+//
+// This bounds size; it does not bound time. A slow client trickling bytes under
+// the limit is the server's ReadTimeout's problem — see ResponseController to
+// adjust that per request.
+func MaxRequestBodySize(n int64) keelhttp.Middleware {
+	return func(l *zap.Logger, name string, next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > n {
+				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+				return
+			}
+
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(w, r.Body, n)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/net/http/middleware/maxrequestbodysize_test.go
+++ b/net/http/middleware/maxrequestbodysize_test.go
@@ -1,0 +1,54 @@
+package middleware_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/foomo/keel/net/http/middleware"
+)
+
+func TestMaxRequestBodySize(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		hideLength bool
+		wantCode   int
+		wantErr    bool // handler's read of the body fails
+	}{
+		{name: "under the limit", body: "1234", wantCode: http.StatusOK},
+		{name: "at the limit", body: "1234567890", wantCode: http.StatusOK},
+		{name: "declared over the limit", body: "12345678901", wantCode: http.StatusRequestEntityTooLarge},
+		{name: "undeclared over the limit", body: "12345678901", hideLength: true, wantCode: http.StatusOK, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var readErr error
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(tt.body))
+			if tt.hideLength {
+				r.ContentLength = -1
+			}
+
+			rec := httptest.NewRecorder()
+
+			middleware.MaxRequestBodySize(10)(zap.NewNop(), "test",
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, readErr = io.ReadAll(r.Body)
+				}),
+			).ServeHTTP(rec, r)
+
+			assert.Equal(t, tt.wantCode, rec.Code)
+
+			var maxErr *http.MaxBytesError
+			assert.Equal(t, tt.wantErr, errors.As(readErr, &maxErr))
+		})
+	}
+}

--- a/net/http/middleware/responsecontroller.go
+++ b/net/http/middleware/responsecontroller.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/foomo/keel/log"
+	keelhttp "github.com/foomo/keel/net/http"
+)
+
+// ResponseController middleware runs h against the request's
+// http.ResponseController before the handler, to override per connection what
+// the server was constructed with: SetReadDeadline / SetWriteDeadline (the zero
+// time clears a deadline), EnableFullDuplex, Flush.
+//
+//	// SSE: no write deadline
+//	middleware.ResponseController(func(rc *http.ResponseController) error {
+//		return rc.SetWriteDeadline(time.Time{})
+//	})
+//
+//	// large upload: read for as long as it takes, bound the body instead
+//	middleware.ResponseController(func(rc *http.ResponseController) error {
+//		return rc.SetReadDeadline(time.Now().Add(10 * time.Minute))
+//	})
+//
+// An error from h is logged and the handler still runs — a ResponseWriter that
+// does not support the operation must not fail the request.
+//
+// IdleTimeout is out of reach here: it governs the connection between requests,
+// when no handler is running, so there is nothing to hang a middleware on. It
+// stays a server value (see keelhttp.NewServer) and must exceed the idle timeout
+// of whatever sits in front of the pod — GCLB 600s, nginx-ingress 75s, ALB 60s —
+// so that side always closes first. If the server expires first, the balancer
+// hands the next request to a socket the server is closing and returns a 502.
+func ResponseController(h func(rc *http.ResponseController) error) keelhttp.Middleware {
+	return func(l *zap.Logger, name string, next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if h != nil {
+				if err := h(http.NewResponseController(w)); err != nil {
+					l.Warn("failed to apply response controller", log.FError(err))
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/net/http/middleware/responsecontroller_test.go
+++ b/net/http/middleware/responsecontroller_test.go
@@ -1,0 +1,64 @@
+package middleware_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/foomo/keel/net/http/middleware"
+)
+
+// deadlineRecorder captures what http.NewResponseController sets.
+type deadlineRecorder struct {
+	http.ResponseWriter
+	write    time.Time
+	writeSet bool
+}
+
+func (w *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	w.write, w.writeSet = t, true
+	return nil
+}
+
+func TestResponseController(t *testing.T) {
+	tests := []struct {
+		name     string
+		h        func(rc *http.ResponseController) error
+		writeSet bool
+	}{
+		{name: "nil handler is a no-op"},
+		{
+			name:     "clears the write deadline",
+			h:        func(rc *http.ResponseController) error { return rc.SetWriteDeadline(time.Time{}) },
+			writeSet: true,
+		},
+		{
+			name: "error does not fail the request",
+			h:    func(rc *http.ResponseController) error { return errors.New("boom") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &deadlineRecorder{ResponseWriter: httptest.NewRecorder()}
+
+			var called bool
+
+			middleware.ResponseController(tt.h)(zap.NewNop(), "test",
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }),
+			).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+			assert.True(t, called, "handler must always run")
+			assert.Equal(t, tt.writeSet, rec.writeSet)
+
+			if tt.writeSet {
+				assert.True(t, rec.write.IsZero())
+			}
+		})
+	}
+}

--- a/net/http/server.go
+++ b/net/http/server.go
@@ -45,11 +45,24 @@ func NewServer(l *zap.Logger, name, addr string, handler http.Handler, middlewar
 		// http.NewResponseController(w).SetWriteDeadline(time.Time{}).
 		WriteTimeout: 60 * time.Second,
 
-		// Must exceed every client's IdleConnTimeout so the client is always the
-		// side that closes an idle connection. Otherwise both expire together
-		// and the client hits a FIN mid-request, surfacing as intermittent EOF.
-		// Clients here use 30s (internal) and 60s (external).
-		IdleTimeout: 120 * time.Second,
+		// Must exceed the idle timeout of whatever is on the other side, so that
+		// side is always the one closing an idle connection. Otherwise both
+		// expire together and the peer is handed a socket this server is
+		// closing: intermittent EOF in-cluster, 502s behind a load balancer.
+		//
+		// 620s is Google's recommended backend value and clears every managed
+		// L7 we run behind: GCLB 600s (fixed), Azure App Gateway 240s public /
+		// 300s private, ingress-nginx 60s, ALB 60s. In-cluster clients close far
+		// sooner (IdleConnTimeout 30s internal, 60s external), so they remain
+		// the closing side too. An Envoy sidecar defaults to 1h and is the one
+		// peer this cannot outlast — it reconnects per request, so its worst
+		// case is a retry rather than a 502.
+		//
+		// The cost is idle connections living ~10 minutes: bounded here, since
+		// the peer is always an ingress pool or a known set of pods. Lower it if
+		// a pod is ever exposed by Service type=LoadBalancer or NodePort, where
+		// the far end is unbounded and untrusted.
+		IdleTimeout: 620 * time.Second,
 
 		MaxHeaderBytes: 1 << 20,
 		Protocols:      &proto,


### PR DESCRIPTION
### Description

Add `ResponseController` and `MaxRequestBodySize` HTTP middlewares, and raise the server `IdleTimeout` to 620s.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- `middleware.ResponseController(h)` — runs `h` against the request's `http.ResponseController` before the handler, so read/write deadlines, full duplex and flush can be overridden per connection (e.g. clearing the write deadline for SSE). An error from `h` is logged and the handler still runs.
- `middleware.MaxRequestBodySize(n)` — rejects a declared `Content-Length` over `n` with 413 before the handler runs, and wraps the body in `http.MaxBytesReader` so chunked or lying clients fail on read with `*http.MaxBytesError`.
- `net/http/server.go` — `IdleTimeout` 120s → 620s so the peer is always the side closing an idle connection; comment documents the managed-L7 values it clears (GCLB 600s, Azure App Gateway 240/300s, ingress-nginx 60s, ALB 60s) and the Envoy-sidecar caveat.
- Table-driven tests for both middlewares.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.